### PR TITLE
Views cleanup

### DIFF
--- a/views/reports/index.ctp
+++ b/views/reports/index.ctp
@@ -32,7 +32,7 @@
 		<div class="report clearfix">
 			<div class="chart">
 			<?php
-			$d1 = ( $ministryCounts['total'] != 0 ) ? floor($ministryCounts['active']/$ministryCounts['total']*100) : 0;
+			$d1 = ($ministryCounts['total'] != 0) ? floor($ministryCounts['active']/$ministryCounts['total']*100) : 0;
 			$d2 = 100-$d1;
 			echo $this->Charts->draw('pie', array(
 				'data' => array($d1, $d2),
@@ -54,7 +54,7 @@
 		<div class="report clearfix">
 			<div class="chart">
 			<?php
-			$d1 = ( $ministryCounts['total'] != 0 ) ? floor($ministryCounts['private']/$ministryCounts['total']*100) : 0;
+			$d1 = ($ministryCounts['total'] != 0) ? floor($ministryCounts['private']/$ministryCounts['total']*100) : 0;
 			$d2 = 100-$d1;
 			echo $this->Charts->draw('pie', array(
 				'data' => array($d1, $d2),
@@ -79,7 +79,7 @@
 		<div class="report clearfix">
 			<div class="chart">
 			<?php
-			$d1 = ( $userCounts['total'] != 0 ) ? floor($userCounts['active']/$userCounts['total']*100) : 0;
+			$d1 = ($userCounts['total'] != 0) ? floor($userCounts['active']/$userCounts['total']*100) : 0;
 			$d2 = 100-$d1;
 			echo $this->Charts->draw('pie', array(
 				'data' => array($d1, $d2),
@@ -122,9 +122,12 @@
 			$total += $involvementCounts[$type]['total'];
 		}
 		foreach ($involvementTypes as $type) {
-			$data[] = ( $total != 0 ) ? floor($involvementCounts[$type]['total']/$total*100) : 0;
+			$data[] = ($total != 0) ? floor($involvementCounts[$type]['total']/$total*100) : 0;
 		}
-		echo ( $total == 0 ) ? '<p>No involvement opportunities found</p>' : $this->Charts->draw('bar', array(
+		if ($total == 0) {
+                    echo '<p>No involvement opportunities found</p>';
+                } else {
+                    echo $this->Charts->draw('bar', array(
 			'spacing' => array(
 				'width' => 30,
 				'padding' => 5
@@ -140,7 +143,8 @@
 			'axes' => array(
 				'y' => array_reverse($involvementTypes)
 			)
-		));
+                    ));
+                }
 		?>
 	</div>
 	<?php foreach ($involvementTypes as $type): ?>

--- a/views/rosters/index.ctp
+++ b/views/rosters/index.ctp
@@ -211,8 +211,8 @@ $this->Paginator->options(array(
 		} else {
 			echo $this->Html->link($name, '#', array('escape' => false));
 		}
-                $tooltipWrapper = ( $fullAccess || $viewProfilePermission );
-                if ( $tooltipWrapper ) : ?>
+                $tooltipWrapper = ($fullAccess || $viewProfilePermission);
+                if ($tooltipWrapper): ?>
                 &nbsp;<div class="core-tooltip"><?php
                 endif;
 			if ($fullAccess) {
@@ -222,7 +222,9 @@ $this->Paginator->options(array(
 			if ($viewProfilePermission) {
 				echo $this->Html->link('View Profile', array('controller' => 'profiles', 'action' => 'view', 'User' => $roster['User']['id']));
 			}
-                if ( $tooltipWrapper) echo '</div>';
+                if ($tooltipWrapper) {
+                    echo '</div>';
+                }
 			?>
 		</td>
 		<td><?php echo $this->Formatting->email($roster['Profile']['primary_email'], $roster['User']['id']); ?>&nbsp;</td>


### PR DESCRIPTION
Cleaned up reports view to handle condition where there are no involvements without divide-by-zero exceptions. Also don't display the chart if there is no data for it since passing it an invalid $data array causes more errors.

On the roster view, the tips of the qtips that pop up over each username would show up even if there weren't any menu options in the qtip content because the `<div class="core-tooltip">` would show up regardless. So now it checks to see if there will be any menu items first. This bug was present in at least Firefox and Chrome.

Not sure if or how testing applies to view templates.
